### PR TITLE
Fix for CH3-2 example not working as described

### DIFF
--- a/ch03/ch03_02_moving-light.html
+++ b/ch03/ch03_02_moving-light.html
@@ -33,8 +33,11 @@
       // Calculate the normal vector
       vec3 N = normalize(vec3(uNormalMatrix * vec4(aVertexNormal, 1.0)));
 
+      // Attach the light to the model transformation matrix
+      vec3 light=vec3(uModelViewMatrix*vec4(uLightDirection,0.));
+      
       // Normalized light direction
-      vec3 L = normalize(uLightDirection);
+      vec3 L = normalize(light);
 
       // Dot product of the normal product and negative light direction vector
       float lambertTerm = dot(N, -L);
@@ -56,7 +59,7 @@
     #version 300 es
 		precision mediump float;
 
-    // Expect the interpolated value fro, the vertex shader
+    // Expect the interpolated value from the vertex shader
     in vec4 vVertexColor;
 
     // Return the final color as fragColor


### PR DESCRIPTION
The book mentions that there is a small change to the vertex shader and that the sphere should rotate with the light, however the light remains static while the sphere spins

### Before
![ezgif com-video-to-gif (5)](https://user-images.githubusercontent.com/7666455/79057709-22514700-7c19-11ea-8feb-84eb73cf6afc.gif)

### After
![ezgif com-video-to-gif (6)](https://user-images.githubusercontent.com/7666455/79057711-25e4ce00-7c19-11ea-947d-f3038795cda5.gif)
